### PR TITLE
Remove default prefix

### DIFF
--- a/src/ElementResolver.php
+++ b/src/ElementResolver.php
@@ -53,7 +53,7 @@ class ElementResolver
      * @param  string  $prefix
      * @return void
      */
-    public function __construct($driver, $prefix = 'body')
+    public function __construct($driver, $prefix = '')
     {
         $this->driver = $driver;
         $this->prefix = trim($prefix);


### PR DESCRIPTION
Remove default prefix `body`
Sometimes need to get meta data of page